### PR TITLE
fix: remove pip cache from setup-python actions

### DIFF
--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: "pip"
 
       - name: Install UV (Python package manager)
         run: |
@@ -77,7 +76,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: "pip"
 
       - name: Install dependencies
         run: |
@@ -148,7 +146,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: "pip"
 
       - name: Install licensecheck
         run: |


### PR DESCRIPTION
- Removed cache: pip from all three jobs (ash-security-scan, ferret-scan, license-compliance)
- Cache requires requirements.txt or pyproject.toml which don't exist in this repo
- Dependencies are installed directly via pip/uvx in subsequent steps

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
