### PR TITLE
fix: add security-events write permission at workflow level

### DIFF
--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -21,6 +21,7 @@ env:
 # Set minimal permissions at workflow level, override in jobs as needed
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   # ASH Security Scanning


### PR DESCRIPTION
- Added security-events: write to workflow-level permissions
- This allows SARIF upload to GitHub Security tab
- Fixes 'Resource not accessible by integration' error for CodeQL action

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
