### PR TITLE
fix: integrate ASH component and remove incomplete job definition

### DIFF
--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run ASH Security Scan
         run: |
           echo "Running ASH (Automated Security Helper) security analysis..."
-          uvx git+https://github.com/awslabs/automated-security-helper.git@v3.1.5 --mode precommit
+          uvx git+https://github.com/awslabs/automated-security-helper.git --mode precommit
         continue-on-error: true
 
       - name: Upload ASH Results

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,8 @@
 # Scans for sensitive data, PII, and security vulnerabilities with GitLab Security Dashboard integration
 
 # Include ASH (Automated Security Helper) component
-# Replace with your own ASH component URL or remove if not using GitLab components
-# include:
-#   - component: <YOUR_ASH_COMPONENT_URL>
+include:
+  - component: code.aws.dev/proserve/automated-security-helper/automated-security-helper/ash@~latest
 
 variables:
   # Python version (latest stable)
@@ -26,10 +25,6 @@ cache:
     - .cache/pip
   policy: pull-push
   when: on_success
-
-# Override ASH job to run in security stage
-ash-sast:
-  stage: security
 
 # Ferret Scan SAST integration for GitLab Security Dashboard
 ferret-scan:


### PR DESCRIPTION
GitLab CI:
- Added ASH component from code.aws.dev for proper security scanning
- Removed incomplete ash-sast job that was causing pipeline errors
- ASH will now run via the included component instead of manual job definition

GitHub Actions:
- Removed version pin from ASH to always use latest version
- Changed from @v3.1.5 to latest for automatic updates

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
