### PR TITLE
chore: update pre-commit hooks and fix CI configurations

### DIFF
--- a/.pre-commit-config-security-linting.yaml
+++ b/.pre-commit-config-security-linting.yaml
@@ -32,7 +32,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.14.14
     hooks:
       - id: ruff
         args: [--fix]
@@ -76,7 +76,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.0.0-rc.0
+    rev: v10.0.0-rc.2
     hooks:
       - id: eslint
         args:
@@ -130,7 +130,7 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.1.5
+    rev: v3.1.7
     hooks:
       - id: ash-simple-scan
 
@@ -147,7 +147,7 @@ repos:
             "--checks",
             "EMAIL,INTELLECTUAL_PROPERTY,IP_ADDRESS,SECRETS,SOCIAL_MEDIA",
             "--config",
-            ".devsecops/ferret-scan.yaml"
+            ".devsecops/ferret-scan.yaml",
           ]
         files: '\.(go|java|json|md|py|sh|sql|txt|xml|yaml|yml)$'
         # Note: .js files temporarily removed from files pending performance fix

--- a/.pre-commit-config-security.yaml
+++ b/.pre-commit-config-security.yaml
@@ -31,7 +31,7 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.1.5
+    rev: v3.1.7
     hooks:
       - id: ash-simple-scan
 
@@ -48,7 +48,7 @@ repos:
             "--checks",
             "EMAIL,INTELLECTUAL_PROPERTY,IP_ADDRESS,SECRETS,SOCIAL_MEDIA",
             "--config",
-            ".devsecops/ferret-scan.yaml"
+            ".devsecops/ferret-scan.yaml",
           ]
         files: '\.(go|java|json|md|py|sh|sql|txt|xml|yaml|yml)$'
         # Note: .js files temporarily removed from files pending performance fix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.14.14
     hooks:
       - id: ruff
         args: [--fix]
@@ -76,7 +76,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.0.0-rc.0
+    rev: v10.0.0-rc.2
     hooks:
       - id: eslint
         args:
@@ -130,7 +130,7 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.1.5
+    rev: v3.1.7
     hooks:
       - id: ash-simple-scan
 
@@ -147,7 +147,7 @@ repos:
             "--checks",
             "EMAIL,INTELLECTUAL_PROPERTY,IP_ADDRESS,SECRETS,SOCIAL_MEDIA",
             "--config",
-            ".devsecops/ferret-scan.yaml"
+            ".devsecops/ferret-scan.yaml",
           ]
         files: '\.(go|java|json|md|py|sh|sql|txt|xml|yaml|yml)$'
         # Note: .js files temporarily removed from files pending performance fix


### PR DESCRIPTION
Pre-commit configs:
- Updated ASH from v3.1.5 to v3.1.7 in security and security-linting configs
- Updated ruff from v0.9.1 to v0.14.14 in security-linting config
- Updated eslint from v10.0.0-rc.0 to v10.0.0-rc.2 in security-linting config
- All configs now have consistent versions with main config

GitLab CI:
- Added ASH component from code.aws.dev for proper security scanning
- Removed incomplete ash-sast job that was causing pipeline errors

GitHub Actions:
- Removed version pin from ASH to always use latest version

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
