### PR TITLE
chore: sync pre-commit hook versions across all configs

### DIFF
--- a/.pre-commit-config-security-linting.yaml
+++ b/.pre-commit-config-security-linting.yaml
@@ -32,7 +32,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.15.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -128,7 +128,7 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.1.11
+    rev: v3.2.1
     hooks:
       - id: ash-simple-scan
 

--- a/.pre-commit-config-security.yaml
+++ b/.pre-commit-config-security.yaml
@@ -31,7 +31,7 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.1.11
+    rev: v3.2.1
     hooks:
       - id: ash-simple-scan
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.15.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -128,7 +128,7 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.1.11
+    rev: v3.2.1
     hooks:
       - id: ash-simple-scan
 


### PR DESCRIPTION
- ruff: v0.15.0 → v0.15.1
- ASH: v3.1.11 → v3.2.1
- ferret-scan: kept at v1.4.0 (v1.5.0 has broken executable)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
