### PR TITLE
chore: add disable-ip-types to ferret-scan and sync all hook versions

### DIFF
--- a/.pre-commit-config-security-linting.yaml
+++ b/.pre-commit-config-security-linting.yaml
@@ -23,7 +23,7 @@ repos:
         exclude: '(\.min\.(js|css)$|\.bundle\.(js|css)$|package-lock\.json$|yarn\.lock$|\.terraform\.lock\.hcl$)'
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         verbose: true
@@ -32,14 +32,14 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.3.0
     hooks:
       - id: black
         files: '\.py$'
@@ -74,7 +74,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.0.0
+    rev: v10.0.3
     hooks:
       - id: eslint
         args:
@@ -128,12 +128,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.2.1
+    rev: v3.2.3
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.5.1
+    rev: v1.5.3
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -144,6 +144,8 @@ repos:
             "medium,high",
             "--checks",
             "EMAIL,INTELLECTUAL_PROPERTY,IP_ADDRESS,SECRETS,SOCIAL_MEDIA",
+            "--disable-ip-types",
+            "trademark,copyright,trade_secret",
             "--config",
             ".devsecops/ferret-scan.yaml",
           ]
@@ -156,7 +158,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.44.0
+    rev: v1.46.0
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/.pre-commit-config-security.yaml
+++ b/.pre-commit-config-security.yaml
@@ -31,12 +31,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.2.1
+    rev: v3.2.3
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.5.1
+    rev: v1.5.3
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -47,6 +47,8 @@ repos:
             "medium,high",
             "--checks",
             "EMAIL,INTELLECTUAL_PROPERTY,IP_ADDRESS,SECRETS,SOCIAL_MEDIA",
+            "--disable-ip-types",
+            "trademark,copyright,trade_secret",
             "--config",
             ".devsecops/ferret-scan.yaml",
           ]
@@ -59,7 +61,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.44.0
+    rev: v1.46.0
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         exclude: '(\.min\.(js|css)$|\.bundle\.(js|css)$|package-lock\.json$|yarn\.lock$|\.terraform\.lock\.hcl$)'
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         verbose: true
@@ -33,14 +33,14 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.3.0
     hooks:
       - id: black
         files: '\.py$'
@@ -75,7 +75,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.0.0
+    rev: v10.0.3
     hooks:
       - id: eslint
         args:
@@ -129,12 +129,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.2.1
+    rev: v3.2.3
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.5.1
+    rev: v1.5.3
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -145,6 +145,8 @@ repos:
             "medium,high",
             "--checks",
             "EMAIL,INTELLECTUAL_PROPERTY,IP_ADDRESS,SECRETS,SOCIAL_MEDIA",
+            "--disable-ip-types",
+            "trademark,copyright,trade_secret",
             "--config",
             ".devsecops/ferret-scan.yaml",
           ]
@@ -157,7 +159,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.44.0
+    rev: v1.46.0
     hooks:
       - id: cfn-lint
         exclude: ^\.*


### PR DESCRIPTION
- Added --disable-ip-types trademark,copyright,trade_secret to ferret-scan
- Synced all shared hook versions across configs: codespell v2.4.2, ruff v0.15.5, black 26.3.0, eslint v10.0.3, ASH v3.2.3, ferret-scan v1.5.3, cfn-lint v1.46.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
