### PR TITLE
fix: add --disable-ip-types to ferret-scan in all CI pipelines

### DIFF
--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -100,6 +100,7 @@ jobs:
             --output ferret-scan-results.sarif \
             --confidence $FERRET_SCAN_CONFIDENCE \
             --checks $FERRET_SCAN_CHECKS \
+            --disable-ip-types trademark,copyright,trade_secret \
             --no-color \
             --quiet \
             $CONFIG_ARG \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,7 @@ ferret-scan:
         --output ferret-sast-report.json \
         --confidence $FERRET_SCAN_CONFIDENCE \
         --checks $FERRET_SCAN_CHECKS \
+        --disable-ip-types trademark,copyright,trade_secret \
         --no-color \
         --quiet \
         $CONFIG_ARG \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,7 @@ stages:
                 --output ferret-scan-results.sarif \
                 --confidence $(FERRET_SCAN_CONFIDENCE) \
                 --checks $(FERRET_SCAN_CHECKS) \
+                --disable-ip-types trademark,copyright,trade_secret \
                 --no-color \
                 --quiet \
                 $CONFIG_ARG \


### PR DESCRIPTION
- Added --disable-ip-types trademark,copyright,trade_secret to GitHub Actions, GitLab CI, and Azure DevOps pipelines
- Now consistent with pre-commit hook configuration

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
