### PR TITLE
chore: sync pre-commit hook versions across all configs

### DIFF
--- a/.pre-commit-config-security-linting.yaml
+++ b/.pre-commit-config-security-linting.yaml
@@ -32,14 +32,14 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/psf/black
-    rev: 26.3.0
+    rev: 26.3.1
     hooks:
       - id: black
         files: '\.py$'
@@ -74,7 +74,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.0.3
+    rev: v10.2.0
     hooks:
       - id: eslint
         args:
@@ -128,7 +128,7 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.2.3
+    rev: v3.2.5
     hooks:
       - id: ash-simple-scan
 
@@ -158,7 +158,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.46.0
+    rev: v1.48.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/.pre-commit-config-security.yaml
+++ b/.pre-commit-config-security.yaml
@@ -31,7 +31,7 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.2.3
+    rev: v3.2.5
     hooks:
       - id: ash-simple-scan
 
@@ -61,7 +61,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.46.0
+    rev: v1.48.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,14 +33,14 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/psf/black
-    rev: 26.3.0
+    rev: 26.3.1
     hooks:
       - id: black
         files: '\.py$'
@@ -75,7 +75,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.0.3
+    rev: v10.2.0
     hooks:
       - id: eslint
         args:
@@ -129,7 +129,7 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.2.3
+    rev: v3.2.5
     hooks:
       - id: ash-simple-scan
 
@@ -159,7 +159,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.46.0
+    rev: v1.48.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*


### PR DESCRIPTION
Updated to match main config:
- ruff: v0.15.5 → v0.15.9
- black: 26.3.0 → 26.3.1
- eslint: v10.0.3 → v10.2.0
- ASH: v3.2.3 → v3.2.5
- cfn-lint: v1.46.0 → v1.48.1

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
