### PR TITLE
chore: sync pre-commit hook versions across all configs

### DIFF
--- a/.pre-commit-config-security-linting.yaml
+++ b/.pre-commit-config-security-linting.yaml
@@ -32,7 +32,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -74,7 +74,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.2.0
+    rev: v10.3.0
     hooks:
       - id: eslint
         args:
@@ -128,12 +128,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.2.5
+    rev: v3.4.0
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.5.3
+    rev: v1.7.1
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -158,7 +158,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.48.1
+    rev: v1.50.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/.pre-commit-config-security.yaml
+++ b/.pre-commit-config-security.yaml
@@ -31,12 +31,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.2.5
+    rev: v3.4.0
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.5.3
+    rev: v1.7.1
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -61,7 +61,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.48.1
+    rev: v1.50.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -75,7 +75,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.2.0
+    rev: v10.3.0
     hooks:
       - id: eslint
         args:
@@ -129,12 +129,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.2.5
+    rev: v3.4.0
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.5.3
+    rev: v1.7.1
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -159,7 +159,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.48.1
+    rev: v1.50.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*


### PR DESCRIPTION
Updated to match main config:
- ruff: v0.15.9 → v0.15.12
- eslint: v10.2.0 → v10.3.0
- ASH: v3.2.5 → v3.4.0
- ferret-scan: v1.5.3 → v1.7.1
- cfn-lint: v1.48.1 → v1.50.1

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
