### PR TITLE
fix: repair broken check-yaml and safety pre-commit hooks (v1.1.0)

### DIFF
--- a/.pre-commit-config-security-linting.yaml
+++ b/.pre-commit-config-security-linting.yaml
@@ -10,6 +10,7 @@ repos:
       - id: check-json
         exclude: '(package-lock\.json$|yarn\.lock$|pnpm-lock\.yaml$|cdk\.context\.json$|\.vscode/|\.idea/|\.terraform/)'
       - id: check-yaml
+        args: ["--unsafe", "--allow-multiple-documents"]
       - id: debug-statements
       - id: detect-private-key
         exclude: '(\.terraform/|node_modules/|\.venv/|venv/|\.virtualenv/|vendor/|Pods/)'
@@ -32,7 +33,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.13
+    rev: v0.15.15
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -45,12 +46,12 @@ repos:
         files: '\.py$'
         exclude: '(\.venv/|venv/|\.virtualenv/|__pycache__/|\.pytest_cache/|\.mypy_cache/|\.ruff_cache/|\.tox/|.*\.pyc$|.*\.pyo$)'
 
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.4.2
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.10.0
     hooks:
-      - id: python-safety-dependencies-check
-        files: requirements.*\.txt$
-        exclude: pyproject\.toml
+      - id: pip-audit
+        args: ["-r", "requirements.txt"]
+        files: requirements\.txt$
 
   # ============================================================================
   # LANGUAGE-SPECIFIC: GO
@@ -133,7 +134,7 @@ repos:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.7.1
+    rev: v1.8.3
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -158,7 +159,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.51.0
+    rev: v1.51.2
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/.pre-commit-config-security.yaml
+++ b/.pre-commit-config-security.yaml
@@ -10,6 +10,7 @@ repos:
       - id: check-json
         exclude: '(package-lock\.json$|yarn\.lock$|pnpm-lock\.yaml$|cdk\.context\.json$|\.vscode/|\.idea/|\.terraform/)'
       - id: check-yaml
+        args: ["--unsafe", "--allow-multiple-documents"]
       - id: debug-statements
       - id: detect-private-key
         exclude: '(\.terraform/|node_modules/|\.venv/|venv/|\.virtualenv/|vendor/|Pods/)'
@@ -20,12 +21,12 @@ repos:
   # ============================================================================
   # PYTHON SECURITY
   # ============================================================================
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.4.2
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.10.0
     hooks:
-      - id: python-safety-dependencies-check
-        files: requirements.*\.txt$
-        exclude: pyproject\.toml
+      - id: pip-audit
+        args: ["-r", "requirements.txt"]
+        files: requirements\.txt$
 
   # ============================================================================
   # SECURITY SCANNING
@@ -36,7 +37,7 @@ repos:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.7.1
+    rev: v1.8.3
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -61,7 +62,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.51.0
+    rev: v1.51.2
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: check-json
         exclude: '(package-lock\.json$|yarn\.lock$|pnpm-lock\.yaml$|cdk\.context\.json$|\.vscode/|\.idea/|\.terraform/)'
       - id: check-yaml
+        args: ["--unsafe", "--allow-multiple-documents"]
       - id: debug-statements
       - id: detect-private-key
         exclude: '(\.terraform/|node_modules/|\.venv/|venv/|\.virtualenv/|vendor/|Pods/)'
@@ -33,7 +34,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.13
+    rev: v0.15.15
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -46,12 +47,12 @@ repos:
         files: '\.py$'
         exclude: '(\.venv/|venv/|\.virtualenv/|__pycache__/|\.pytest_cache/|\.mypy_cache/|\.ruff_cache/|\.tox/|.*\.pyc$|.*\.pyo$)'
 
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.4.2
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.10.0
     hooks:
-      - id: python-safety-dependencies-check
-        files: requirements.*\.txt$
-        exclude: pyproject\.toml
+      - id: pip-audit
+        args: ["-r", "requirements.txt"]
+        files: requirements\.txt$
 
   # ============================================================================
   # LANGUAGE-SPECIFIC: GO
@@ -134,7 +135,7 @@ repos:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.7.1
+    rev: v1.8.3
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -159,7 +160,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.51.0
+    rev: v1.51.2
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-VERSION="1.0.0"
+VERSION="1.1.0"
 REPO_URL="https://github.com/awslabs/devsecops-pre-commit-and-cicd-template.git"
 TEMP_DIR="$(mktemp -d)/DevSecOps"
 


### PR DESCRIPTION
## Summary

Two pre-commit hooks shipped by this template fail in consuming repos. Both are fixed across all three config variants (`.pre-commit-config.yaml`, `.pre-commit-config-security.yaml`, `.pre-commit-config-security-linting.yaml`), and version drift between the variants is reconciled.

## What was broken

**1. `check-yaml` ran bare (no args)**
The hook applied a strict `yaml.safe_load` to every YAML file, causing hard commit failures on:
- CloudFormation short-hand tags — `could not determine a constructor for the tag '!Sub'` (also `!Ref`, `!GetAtt`)
- Multi-document YAML (e.g. Kubernetes manifests) — `expected a single document in the stream`

These are exactly the file types this template is dropped into.

**2. `python-safety-dependencies-check` (`Lucas-C/pre-commit-hooks-safety` v1.4.2)**
The modern `safety` CLI deprecated `check` in favor of an auth-gated `safety scan`. The pinned wrapper still calls the old path, so the hook breaks in non-interactive contexts (CI and local commits) — either erroring or blocking on credentials that aren't present.

## Changes

- **`check-yaml`** → added `args: ["--unsafe", "--allow-multiple-documents"]` (tolerates CFN/GitLab custom tags, handles multi-doc YAML)
- **`python-safety-dependencies-check`** → replaced with **`pypa/pip-audit` v2.10.0**, gated on `requirements.txt`. `pip-audit` requires no account or auth, making it a better fit for a template distributed to external repos.
- **Version drift reconciled** so all three configs match:
  - `ferret-scan` v1.7.1 → **v1.8.3** (security + linting variants)
  - `cfn-lint` v1.51.0 → **v1.51.2** (security + linting variants)
  - `ruff` v0.15.13 → **v0.15.15** (linting variant)
- **`setup.sh`** `VERSION` 1.0.0 → **1.1.0**

## Testing

- `pre-commit validate-config` passes on all three config files
- Reproduced the original failure: bare `check-yaml` fails on a CFN-tag + multi-doc fixture (exit 1)
- Confirmed the fix: `check-yaml --unsafe --allow-multiple-documents` passes on the same files (exit 0)
- `pip-audit` (via `pre-commit try-repo` @ v2.10.0) installs and runs cleanly
- `pip-audit -r requirements.txt` against `flask==0.5` detects 4 CVEs and exits non-zero (the dependency-scan coverage the broken `safety` hook was supposed to provide)
- `files: requirements\.txt$` gate matches `requirements.txt` / `dev-requirements.txt` / `src/requirements.txt` and correctly skips `pyproject.toml`, `requirements.in`, etc.

## Note for downstream

If any consumer runs these hooks on **pre-commit.ci** (which blocks network calls), add the following so `pip-audit` only runs locally:

```yaml
ci:
  skip: [pip-audit]
```

This repo's own pipelines (GitHub Actions / GitLab CI / Azure) run ASH separately, so no change is needed here.
