### PR TITLE
chore: update hook versions, add Kotlin/Swift support, pin licenseche…

### DIFF
--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -34,10 +34,10 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -53,7 +53,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload ASH Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ash-security-results
@@ -71,10 +71,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -119,7 +119,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Ferret Scan Results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: ferret-scan-results.sarif
@@ -127,7 +127,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Ferret Scan Results as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ferret-scan-results
@@ -142,16 +142,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install licensecheck
         run: |
-          pip install licensecheck
+          pip install "licensecheck>=2025.1.0,<2026"
 
       - name: Run License Compliance Check
         run: |
@@ -160,7 +160,7 @@ jobs:
           echo "✓ All licenses are compliant"
 
       - name: Upload License Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: license-compliance-report

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,7 @@ license-compliance:
     policy: pull-push
     when: on_success
   before_script:
-    - pip install --cache-dir .cache/pip licensecheck
+    - pip install --cache-dir .cache/pip "licensecheck>=2025.1.0,<2026"
   script:
     - echo "Checking license compliance..."
     # Run licensecheck

--- a/.pre-commit-config-security-linting.yaml
+++ b/.pre-commit-config-security-linting.yaml
@@ -24,7 +24,7 @@ repos:
         exclude: '(\.min\.(js|css)$|\.bundle\.(js|css)$|package-lock\.json$|yarn\.lock$|\.terraform\.lock\.hcl$)'
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         verbose: true
@@ -33,7 +33,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -47,7 +47,7 @@ repos:
         exclude: '(\.venv/|venv/|\.virtualenv/|__pycache__/|\.pytest_cache/|\.mypy_cache/|\.ruff_cache/|\.tox/|.*\.pyc$|.*\.pyo$)'
 
   - repo: https://github.com/pypa/pip-audit
-    rev: v2.10.0
+    rev: v2.10.1
     hooks:
       - id: pip-audit
         args: ["-r", "requirements.txt"]
@@ -75,7 +75,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.4.0
+    rev: v10.7.0
     hooks:
       - id: eslint
         args:
@@ -102,7 +102,7 @@ repos:
         exclude: '(node_modules/|dist/|build/|\.next/|\.nuxt/|\.svelte-kit/|\.turbo/|coverage/|\.min\.(js|css)$|\.bundle\.(js|css)$|package-lock\.json$|yarn\.lock$|pnpm-lock\.yaml$|cdk\.context\.json$)'
 
   # ============================================================================
-  # LANGUAGE-SPECIFIC: JAVA
+  # LANGUAGE-SPECIFIC: JAVA & KOTLIN
   # ============================================================================
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.16.0
@@ -110,12 +110,15 @@ repos:
       - id: pretty-format-java
         args: [--autofix]
         files: '\.java$'
+      - id: pretty-format-kotlin
+        args: [--autofix]
+        files: '\.(kt|kts)$'
 
   # ============================================================================
   # INFRASTRUCTURE AS CODE: TERRAFORM
   # ============================================================================
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: v1.108.0
     hooks:
       - id: terraform_fmt
         files: '\.tf$'
@@ -129,12 +132,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.5.3
+    rev: v3.5.7
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.8.3
+    rev: v2.1.1
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -150,8 +153,7 @@ repos:
             "--config",
             ".devsecops/ferret-scan.yaml",
           ]
-        files: '\.(go|java|json|md|py|sh|sql|txt|xml|yaml|yml)$'
-        # Note: .js files temporarily removed from files pending performance fix
+        files: '\.(go|java|json|kt|kts|md|py|sh|sql|swift|txt|xml|yaml|yml)$'
         exclude: '(^\.git/|\.ash/|\.cache/|\.devsecops/|\.dsr/|\.idea/|\.kiro/|\.venv/|\.virtualenv/|__pycache__/|\.pytest_cache/|\.mypy_cache/|\.ruff_cache/|\.tox/|\.terraform/|\.next/|\.nuxt/|\.svelte-kit/|\.turbo/|\.docusaurus/|_build/|site/|bin/|cdk\.out/|dist/|node_modules/|\.pnpm-store/|\.yarn/|bower_components/|\.vscode/|out/|\.output/|\.nyc_output/|test-results/|reports/|tmp/|temp/|logs/|setup\.sh|vendor/|Pods/|venv/|test_|_test\.|^README\.md$|\.DS_Store$|Thumbs\.db$|.*\.pyc$|.*\.pyo$|.*\.swp$|.*\.swo$|.*\.log$|package-lock\.json$|yarn\.lock$|pnpm-lock\.yaml$|poetry\.lock$|Pipfile\.lock$|Gemfile\.lock$|\.terraform\.lock\.hcl$|terraform\.tfstate$|cdk\.context\.json$)'
         pass_filenames: true
 
@@ -159,7 +161,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.51.2
+    rev: v1.53.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/.pre-commit-config-security.yaml
+++ b/.pre-commit-config-security.yaml
@@ -22,7 +22,7 @@ repos:
   # PYTHON SECURITY
   # ============================================================================
   - repo: https://github.com/pypa/pip-audit
-    rev: v2.10.0
+    rev: v2.10.1
     hooks:
       - id: pip-audit
         args: ["-r", "requirements.txt"]
@@ -32,12 +32,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.5.3
+    rev: v3.5.7
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.8.3
+    rev: v2.1.1
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -53,8 +53,7 @@ repos:
             "--config",
             ".devsecops/ferret-scan.yaml",
           ]
-        files: '\.(go|java|json|md|py|sh|sql|txt|xml|yaml|yml)$'
-        # Note: .js files temporarily removed from files pending performance fix
+        files: '\.(go|java|json|kt|kts|md|py|sh|sql|swift|txt|xml|yaml|yml)$'
         exclude: '(^\.git/|\.ash/|\.cache/|\.devsecops/|\.dsr/|\.idea/|\.kiro/|\.venv/|\.virtualenv/|__pycache__/|\.pytest_cache/|\.mypy_cache/|\.ruff_cache/|\.tox/|\.terraform/|\.next/|\.nuxt/|\.svelte-kit/|\.turbo/|\.docusaurus/|_build/|site/|bin/|cdk\.out/|dist/|node_modules/|\.pnpm-store/|\.yarn/|bower_components/|\.vscode/|out/|\.output/|\.nyc_output/|test-results/|reports/|tmp/|temp/|logs/|setup\.sh|vendor/|Pods/|venv/|test_|_test\.|^README\.md$|\.DS_Store$|Thumbs\.db$|.*\.pyc$|.*\.pyo$|.*\.swp$|.*\.swo$|.*\.log$|package-lock\.json$|yarn\.lock$|pnpm-lock\.yaml$|poetry\.lock$|Pipfile\.lock$|Gemfile\.lock$|\.terraform\.lock\.hcl$|terraform\.tfstate$|cdk\.context\.json$)'
         pass_filenames: true
 
@@ -62,13 +61,13 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.51.2
+    rev: v1.53.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: v1.108.0
     hooks:
       - id: terraform_tflint
         files: '\.tf$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         exclude: '(\.min\.(js|css)$|\.bundle\.(js|css)$|package-lock\.json$|yarn\.lock$|\.terraform\.lock\.hcl$)'
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         verbose: true
@@ -34,7 +34,7 @@ repos:
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -48,7 +48,7 @@ repos:
         exclude: '(\.venv/|venv/|\.virtualenv/|__pycache__/|\.pytest_cache/|\.mypy_cache/|\.ruff_cache/|\.tox/|.*\.pyc$|.*\.pyo$)'
 
   - repo: https://github.com/pypa/pip-audit
-    rev: v2.10.0
+    rev: v2.10.1
     hooks:
       - id: pip-audit
         args: ["-r", "requirements.txt"]
@@ -76,7 +76,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.4.0
+    rev: v10.7.0
     hooks:
       - id: eslint
         args:
@@ -103,7 +103,7 @@ repos:
         exclude: '(node_modules/|dist/|build/|\.next/|\.nuxt/|\.svelte-kit/|\.turbo/|coverage/|\.min\.(js|css)$|\.bundle\.(js|css)$|package-lock\.json$|yarn\.lock$|pnpm-lock\.yaml$|cdk\.context\.json$)'
 
   # ============================================================================
-  # LANGUAGE-SPECIFIC: JAVA
+  # LANGUAGE-SPECIFIC: JAVA & KOTLIN
   # ============================================================================
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.16.0
@@ -111,12 +111,15 @@ repos:
       - id: pretty-format-java
         args: [--autofix]
         files: '\.java$'
+      - id: pretty-format-kotlin
+        args: [--autofix]
+        files: '\.(kt|kts)$'
 
   # ============================================================================
   # INFRASTRUCTURE AS CODE: TERRAFORM
   # ============================================================================
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: v1.108.0
     hooks:
       - id: terraform_fmt
         files: '\.tf$'
@@ -130,12 +133,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.5.3
+    rev: v3.5.7
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v1.8.3
+    rev: v2.1.1
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -151,8 +154,7 @@ repos:
             "--config",
             ".devsecops/ferret-scan.yaml",
           ]
-        files: '\.(go|java|json|md|py|sh|sql|txt|xml|yaml|yml)$'
-        # Note: .js files temporarily removed from files pending performance fix
+        files: '\.(go|java|json|kt|kts|md|py|sh|sql|swift|txt|xml|yaml|yml)$'
         exclude: '(^\.git/|\.ash/|\.cache/|\.devsecops/|\.dsr/|\.idea/|\.kiro/|\.venv/|\.virtualenv/|__pycache__/|\.pytest_cache/|\.mypy_cache/|\.ruff_cache/|\.tox/|\.terraform/|\.next/|\.nuxt/|\.svelte-kit/|\.turbo/|\.docusaurus/|_build/|site/|bin/|cdk\.out/|dist/|node_modules/|\.pnpm-store/|\.yarn/|bower_components/|\.vscode/|out/|\.output/|\.nyc_output/|test-results/|reports/|tmp/|temp/|logs/|setup\.sh|vendor/|Pods/|venv/|test_|_test\.|^README\.md$|\.DS_Store$|Thumbs\.db$|.*\.pyc$|.*\.pyo$|.*\.swp$|.*\.swo$|.*\.log$|package-lock\.json$|yarn\.lock$|pnpm-lock\.yaml$|poetry\.lock$|Pipfile\.lock$|Gemfile\.lock$|\.terraform\.lock\.hcl$|terraform\.tfstate$|cdk\.context\.json$)'
         pass_filenames: true
 
@@ -160,7 +162,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.51.2
+    rev: v1.53.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*

--- a/README.md
+++ b/README.md
@@ -440,13 +440,13 @@ detect-secrets scan --json
 curl -sSfL https://astral.sh/uv/install.sh | sh
 
 # Run ASH in local mode
-uvx git+https://github.com/awslabs/automated-security-helper.git@v3.1.2 --mode local
+uvx git+https://github.com/awslabs/automated-security-helper.git@v3.5.7 --mode local
 
 # Run ASH in container mode (all tools)
-uvx git+https://github.com/awslabs/automated-security-helper.git@v3.1.2 --mode container
+uvx git+https://github.com/awslabs/automated-security-helper.git@v3.5.7 --mode container
 
 # Run ASH in precommit mode (fast)
-uvx git+https://github.com/awslabs/automated-security-helper.git@v3.1.2 --mode precommit
+uvx git+https://github.com/awslabs/automated-security-helper.git@v3.5.7 --mode precommit
 ```
 
 ### Python Safety

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,7 +134,7 @@ stages:
               versionSpec: $(PYTHON_VERSION)
 
           - script: |
-              pip install licensecheck
+              pip install "licensecheck>=2025.1.0,<2026"
             displayName: "Install licensecheck"
 
           - script: |

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-VERSION="1.1.0"
+VERSION="1.2.0"
 REPO_URL="https://github.com/awslabs/devsecops-pre-commit-and-cicd-template.git"
 TEMP_DIR="$(mktemp -d)/DevSecOps"
 
@@ -72,6 +72,8 @@ DETECTED_TERRAFORM=false
 DETECTED_NODE=false
 DETECTED_GO=false
 DETECTED_JAVA=false
+DETECTED_KOTLIN=false
+DETECTED_SWIFT=false
 
 # Detect Terraform
 if [ -n "$(find . -maxdepth 3 -name '*.tf' -print -quit 2>/dev/null)" ]; then
@@ -100,7 +102,19 @@ if [ -f "pom.xml" ] || [ -f "build.gradle" ] || [ -n "$(find . -maxdepth 3 -name
     echo -e "${BLUE}✓ Detected Java project${NC}"
 fi
 
-if [ "$DETECTED_TERRAFORM" = false ] && [ "$DETECTED_NODE" = false ] && [ "$DETECTED_GO" = false ] && [ "$DETECTED_JAVA" = false ]; then
+# Detect Kotlin
+if [ -f "build.gradle.kts" ] || [ -n "$(find . -maxdepth 3 \( -name '*.kt' -o -name '*.kts' \) -print -quit 2>/dev/null)" ]; then
+    DETECTED_KOTLIN=true
+    echo -e "${BLUE}✓ Detected Kotlin project${NC}"
+fi
+
+# Detect Swift
+if [ -f "Package.swift" ] || [ -n "$(find . -maxdepth 3 -name '*.swift' -print -quit 2>/dev/null)" ]; then
+    DETECTED_SWIFT=true
+    echo -e "${BLUE}✓ Detected Swift project${NC}"
+fi
+
+if [ "$DETECTED_TERRAFORM" = false ] && [ "$DETECTED_NODE" = false ] && [ "$DETECTED_GO" = false ] && [ "$DETECTED_JAVA" = false ] && [ "$DETECTED_KOTLIN" = false ] && [ "$DETECTED_SWIFT" = false ]; then
     echo -e "${YELLOW}ℹ No specific project type detected (Python-only or other)${NC}"
 fi
 
@@ -368,6 +382,7 @@ if [ "$CONFIG_SKIPPED" = false ]; then
                 echo "   • JavaScript/TypeScript: ESLint fixes + Prettier formatting"
                 echo "   • Go: gofmt + goimports formatting"
                 echo "   • Java: Pretty formatting"
+                echo "   • Kotlin: KTLint formatting"
                 echo ""
                 read -p "Continue with auto-formatting configuration? (y/n) " -n 1 -r
                 echo ""
@@ -536,12 +551,14 @@ echo "================================================"
 echo ""
 
 # Show detected project types
-if [ "$DETECTED_TERRAFORM" = true ] || [ "$DETECTED_NODE" = true ] || [ "$DETECTED_GO" = true ] || [ "$DETECTED_JAVA" = true ]; then
+if [ "$DETECTED_TERRAFORM" = true ] || [ "$DETECTED_NODE" = true ] || [ "$DETECTED_GO" = true ] || [ "$DETECTED_JAVA" = true ] || [ "$DETECTED_KOTLIN" = true ] || [ "$DETECTED_SWIFT" = true ]; then
     echo -e "${BLUE}Detected project types:${NC}"
     [ "$DETECTED_TERRAFORM" = true ] && echo "  • Terraform"
     [ "$DETECTED_NODE" = true ] && echo "  • Node.js/JavaScript/TypeScript"
     [ "$DETECTED_GO" = true ] && echo "  • Go"
     [ "$DETECTED_JAVA" = true ] && echo "  • Java"
+    [ "$DETECTED_KOTLIN" = true ] && echo "  • Kotlin"
+    [ "$DETECTED_SWIFT" = true ] && echo "  • Swift"
     echo ""
 fi
 


### PR DESCRIPTION
…ck <2026

Version updates across all pre-commit configs:
- codespell v2.4.2 -> v2.4.3
- ruff-pre-commit v0.15.15 -> v0.15.22
- pip-audit v2.10.0 -> v2.10.1
- mirrors-eslint v10.4.0 -> v10.7.0
- pre-commit-terraform v1.105.0 -> v1.108.0
- automated-security-helper v3.5.3 -> v3.5.7
- ferret-scan v1.8.3 -> v2.1.1 (CLI flags verified compatible)
- cfn-lint v1.51.2 -> v1.53.1

GitHub Actions: checkout v4->v7, setup-python v5->v7, upload-artifact v4->v7, codeql-action v3->v4.

Kotlin/Swift support:
- Add kt|kts|swift to ferret-scan files pattern in all configs
- Add pretty-format-kotlin (KTLint) hook to linting configs
- Detect Kotlin/Swift projects in setup.sh

licensecheck stays at 2025.1.0 and CI pins <2026: the 2026.x release exits 3 (NO_PACKAGES) instead of 0 when a project has no dependencies, and crashes outright when no pyproject.toml or requirements.txt exists - both break template consumers.

Template version bumped to 1.2.0.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
