### PR TITLE
chore: align ferret-scan config with v2 schema, sync hook versions, fix codespell args

### DIFF
--- a/.devsecops/ferret-scan.yaml
+++ b/.devsecops/ferret-scan.yaml
@@ -16,15 +16,19 @@ defaults:
   quiet: false # Suppress progress output (useful for scripts and CI/CD)
   show_suppressed: false # Include suppressed findings in output with suppression details
   generate_suppressions: false # Generate suppression rules for all findings
+  respect_gitignore: false # Honor .gitignore / .git/info/exclude when walking directories
+  fail_on_incomplete: false # Exit code 3 if a file's validator coverage was cut short (timeout/budget)
+  # exclude_patterns:            # Glob patterns to skip; the CI job scans `--file *`
+  #   - "node_modules/**"        # recursively, so excludes here reduce both noise and runtime
+  #   - "dist/**"
 
 # Preprocessor configurations
 preprocessors:
   # Text extraction from documents
   text_extraction:
-    enabled: true # Enable text extraction preprocessor
-    types: # Types of text extraction to perform
-      - pdf # Extract text from PDF documents
-      - office # Extract text from Office documents (DOCX, XLSX, PPTX, ODT, ODS, ODP)
+    # PDF and Office documents are both handled whenever this is on. There is no
+    # per-type selector: a `types:` list here is an unknown key and is ignored.
+    enabled: true
 
   # Metadata extraction (automatically enabled when preprocessors are enabled)
   # Supports multiple file types:
@@ -41,20 +45,11 @@ redaction:
   output_dir: "./redacted" # Directory where redacted files will be stored
   strategy: "format_preserving" # Default redaction strategy: simple, format_preserving, or synthetic
   audit_log_file: "" # Path to save redaction audit log file (JSON format for compliance)
-  memory_scrub: true # Enable secure memory scrubbing after processing sensitive data
-  audit_trail: true # Enable audit trail generation for redaction operations
-
-  # Strategy-specific configurations
-  strategies:
-    simple:
-      replacement: "[REDACTED]" # Text to replace sensitive data with
-
-    format_preserving:
-      preserve_length: true # Maintain original text length
-      preserve_format: true # Maintain original text format (e.g., XXX-XX-XXXX for SSN)
-
-    synthetic:
-      secure: true # Use cryptographically secure synthetic data generation
+  # The strategies are not individually tunable: `simple` always substitutes a fixed
+  # marker, `format_preserving` always preserves length and shape, and `synthetic`
+  # always generates with a cryptographic source. A `strategies:` block, `memory_scrub`
+  # or `audit_trail` here are unknown keys — they are ignored, and previously implied
+  # compliance behavior the scanner does not implement.
 
 # Validator-specific configurations
 validators:
@@ -289,7 +284,14 @@ validators:
       # Twitter/X - Microblogging platform
       twitter:
         - "(?i)https?://(?:www\\.)?(twitter|x)\\.com/[a-zA-Z0-9_]+" # Profile URLs
-        - "(?i)(?<!\\w)@[a-zA-Z0-9_]{1,15}(?!@|\\.[a-zA-Z])" # @mentions and handles
+        # Go uses RE2, which has NO lookaround. The previous form here —
+        # "(?i)(?<!\w)@[a-zA-Z0-9_]{1,15}(?!@|\.[a-zA-Z])" — failed to compile, so it
+        # was silently DROPPED: twitter loaded 2 of 3 patterns and no bare @handle was
+        # ever detected, even though SOCIAL_MEDIA is enabled in CI and pre-commit.
+        # \B before @ reproduces the lookbehind (@ is a non-word char, so \B holds only
+        # when the preceding char is also non-word or start-of-line), which rejects
+        # bob@example.com. The trailing exclusions are enforced in code instead.
+        - "(?i)\\B@[a-zA-Z0-9_]{1,15}\\b" # @mentions and handles
         - "(?i)(twitter|x)\\.com/[a-zA-Z0-9_]+"
 
       # GitHub - Code repository platform
@@ -621,8 +623,24 @@ profiles:
     show_suppressed: true # Show suppressed findings for debugging
     description: "Debug mode with detailed logging and comprehensive output for troubleshooting"
 
-  # CI/CD pipeline profile - JUnit XML output for integration with CI/CD systems
+  # CI/CD pipeline profile - mirrors the ferret-scan job in .gitlab-ci.yml so that
+  # `--profile ci` locally reproduces what the pipeline runs. Keep the two in step:
+  # the job passes --format gitlab-sast, --confidence medium,high and FERRET_SCAN_CHECKS.
   ci:
+    format: gitlab-sast
+    confidence_levels: high,medium
+    checks: CLOUD_RESOURCES,EMAIL,INTELLECTUAL_PROPERTY,IP_ADDRESS,OTP,SECRETS,SOCIAL_MEDIA
+    verbose: true
+    no_color: true
+    recursive: true
+    enable_preprocessors: true
+    quiet: true
+    show_suppressed: false
+    generate_suppressions: false
+    description: "CI/CD pipeline profile matching the GitLab ferret-scan job (gitlab-sast output)"
+
+  # JUnit variant for CI systems that consume test-result XML rather than SAST reports
+  ci-junit:
     format: junit
     confidence_levels: high,medium
     checks: all

--- a/.devsecops/ferret-scan.yaml
+++ b/.devsecops/ferret-scan.yaml
@@ -5,8 +5,7 @@
 defaults:
   format: text # Output format: text, json, csv, yaml, junit
   confidence_levels: all # Confidence levels to display: high, medium, low, or combinations
-  checks:
-    all # Specific checks to run: CREDIT_CARD, PASSPORT, METADATA, INTELLECTUAL_PROPERTY, SSN, SECRETS, EMAIL, PHONE, IP_ADDRESS, or combinations
+  checks: all # Specific checks to run: CREDIT_CARD, PASSPORT, METADATA, INTELLECTUAL_PROPERTY, SSN, SECRETS, EMAIL, PHONE, IP_ADDRESS, or combinations
   verbose: false # Display detailed information for each finding
   debug: false # Enable debug logging to show preprocessing and validation flow
   no_color: false # Disable colored output
@@ -383,6 +382,21 @@ validators:
         - "(?i)https?://(?:www\\.)?clubhouse\\.com/@[a-zA-Z0-9_]+" # Profile URLs
         - "(?i)clubhouse\\.com/@[a-zA-Z0-9_]+" # Without protocol
 
+      # Threads - Meta's text-based conversation platform
+      threads:
+        - "(?i)https?://(?:www\\.)?threads\\.net/@[a-zA-Z0-9_.]+" # Profile URLs
+        - "(?i)threads\\.net/@[a-zA-Z0-9_.]+" # Without protocol
+
+      # Bluesky - Decentralized microblogging platform (AT Protocol)
+      bluesky:
+        - "(?i)https?://(?:www\\.)?bsky\\.app/profile/[a-zA-Z0-9_.-]+" # Profile URLs
+        - "(?i)bsky\\.app/profile/[a-zA-Z0-9_.-]+" # Without protocol
+
+      # Mastodon - Federated microblogging platform (ActivityPub)
+      mastodon:
+        - "(?i)https?://[a-zA-Z0-9_.-]+/@[a-zA-Z0-9_]+@[a-zA-Z0-9_.-]+" # Any instance, full handle
+        - "(?i)https?://(?:mastodon\\.social|mastodon\\.online|mstdn\\.social|fosstodon\\.org)/@[a-zA-Z0-9_]+" # Well-known instances
+
     # Keywords that increase confidence when found near social media patterns
     positive_keywords:
       - "profile"
@@ -567,6 +581,28 @@ validators:
         - "publication"
         - "clap"
 
+      threads:
+        - "post"
+        - "follow"
+        - "thread"
+        - "reply"
+        - "repost"
+
+      bluesky:
+        - "post"
+        - "follow"
+        - "skeet"
+        - "repost"
+        - "feed"
+
+      mastodon:
+        - "toot"
+        - "boost"
+        - "follow"
+        - "instance"
+        - "fediverse"
+        - "federated"
+
     # Patterns to whitelist (reduce false positives)
     whitelist_patterns:
       - "(?i)example\\.com"
@@ -581,8 +617,6 @@ suppressions:
   generate_on_scan: false # Generate suppression rules for all findings during scan
   show_suppressed: false # Include suppressed findings in output
 
-
-
 # Profiles for different scanning scenarios
 profiles:
   # Quick scan profile - only high confidence matches, minimal output
@@ -596,6 +630,12 @@ profiles:
     quiet: true
     show_match: false
     enable_preprocessors: false # Skip document processing for speed
+    respect_gitignore: true # Skip files excluded by .gitignore
+    exclude_patterns: # Directories never worth scanning in a quick pass
+      - ".git"
+      - "node_modules"
+      - "dist/"
+      - "build/"
     description: "Quick scan focusing on critical data types with minimal processing"
 
   # Thorough scan profile - all confidence levels, verbose output, recursive scanning
@@ -607,6 +647,7 @@ profiles:
     no_color: false
     recursive: true
     enable_preprocessors: true
+    respect_gitignore: false # Scan everything, including gitignored files
     description: "Thorough scan with all confidence levels, recursive scanning, and text extraction"
 
   # Debug profile - enables debug logging to show preprocessing and validation flow
@@ -701,7 +742,6 @@ profiles:
           - "http[s]?:\\/\\/monitoring\\.example\\.com" # System monitoring
           - "http[s]?:\\/\\/logs\\.example\\.com" # Log aggregation
 
-
   # Company-specific profile with custom internal URLs and patterns
   company-specific:
     format: text
@@ -746,7 +786,6 @@ profiles:
           # Custom copyright pattern including company name
           copyright: "(©|\\(c\\)|\\(C\\)|Copyright|\\bCopyright\\b)\\s*\\d{4}[-,]?(\\d{4})?\\s+(Company\\s+Name|Company\\s+Inc|[A-Za-z0-9\\s\\.,]+)"
 
-
   # Redaction profile - scan and redact sensitive data with format preservation
   redaction:
     format: text
@@ -778,7 +817,6 @@ profiles:
       output_dir: "./secure-redacted"
       strategy: "synthetic"
       index_file: "./secure-redaction-index.json"
-
 
   # Security audit profile - focused on security-sensitive data types
   security-audit:

--- a/.pre-commit-config-security-linting.yaml
+++ b/.pre-commit-config-security-linting.yaml
@@ -28,12 +28,17 @@ repos:
     hooks:
       - id: codespell
         verbose: true
+        # Must be ONE argument. `[--ignore-words-list=ehr, ser]` is a YAML flow
+        # sequence, so it splits into two args and "ser" becomes a stray
+        # positional filename instead of an ignored word. "ser" occurs inside
+        # the reddit regex `u(?:ser)?` in .devsecops/ferret-scan.yaml.
+        args: ["--ignore-words-list=ehr,ser"]
 
   # ============================================================================
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -75,7 +80,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.7.0
+    rev: v10.8.1
     hooks:
       - id: eslint
         args:
@@ -118,7 +123,7 @@ repos:
   # INFRASTRUCTURE AS CODE: TERRAFORM
   # ============================================================================
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.108.0
+    rev: v1.108.1
     hooks:
       - id: terraform_fmt
         files: '\.tf$'
@@ -132,12 +137,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.5.7
+    rev: v3.5.9
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v2.1.1
+    rev: v2.3.2
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -161,7 +166,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.53.1
+    rev: v1.55.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*
@@ -169,6 +174,15 @@ repos:
   # ============================================================================
   # LICENSE COMPLIANCE
   # ============================================================================
+  # DO NOT bump to 2026.x — `pre-commit autoupdate` will try to. Two regressions
+  # break template consumers:
+  #   1. No pyproject.toml -> hard crash "RuntimeError: All resolvers failed".
+  #      The CLI's hardcoded requirements_paths default ("pyproject.toml")
+  #      overrides the value set in licensecheck.toml, so a project using
+  #      requirements.txt still crashes. Passing --requirements-paths works
+  #      around it, but every path listed must exist or it crashes again.
+  #   2. A project with zero dependencies exits 3 instead of 0.
+  # 2025.1.0 prints "No packages" and exits 0 in both cases.
   - repo: https://github.com/FHPythonUtils/LicenseCheck
     rev: "2025.1.0"
     hooks:

--- a/.pre-commit-config-security.yaml
+++ b/.pre-commit-config-security.yaml
@@ -32,12 +32,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.5.7
+    rev: v3.5.9
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v2.1.1
+    rev: v2.3.2
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -61,13 +61,13 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.53.1
+    rev: v1.55.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.108.0
+    rev: v1.108.1
     hooks:
       - id: terraform_tflint
         files: '\.tf$'
@@ -78,6 +78,15 @@ repos:
   # ============================================================================
   # LICENSE COMPLIANCE
   # ============================================================================
+  # DO NOT bump to 2026.x — `pre-commit autoupdate` will try to. Two regressions
+  # break template consumers:
+  #   1. No pyproject.toml -> hard crash "RuntimeError: All resolvers failed".
+  #      The CLI's hardcoded requirements_paths default ("pyproject.toml")
+  #      overrides the value set in licensecheck.toml, so a project using
+  #      requirements.txt still crashes. Passing --requirements-paths works
+  #      around it, but every path listed must exist or it crashes again.
+  #   2. A project with zero dependencies exits 3 instead of 0.
+  # 2025.1.0 prints "No packages" and exits 0 in both cases.
   - repo: https://github.com/FHPythonUtils/LicenseCheck
     rev: "2025.1.0"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,13 +28,17 @@ repos:
     hooks:
       - id: codespell
         verbose: true
-        args: [--ignore-words-list=ehr, ser]
+        # Must be ONE argument. `[--ignore-words-list=ehr, ser]` is a YAML flow
+        # sequence, so it splits into two args and "ser" becomes a stray
+        # positional filename instead of an ignored word. "ser" occurs inside
+        # the reddit regex `u(?:ser)?` in .devsecops/ferret-scan.yaml.
+        args: ["--ignore-words-list=ehr,ser"]
 
   # ============================================================================
   # LANGUAGE-SPECIFIC: PYTHON
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -76,7 +80,7 @@ repos:
   # LANGUAGE-SPECIFIC: JAVASCRIPT/TYPESCRIPT
   # ============================================================================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.7.0
+    rev: v10.8.1
     hooks:
       - id: eslint
         args:
@@ -119,7 +123,7 @@ repos:
   # INFRASTRUCTURE AS CODE: TERRAFORM
   # ============================================================================
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.108.0
+    rev: v1.108.1
     hooks:
       - id: terraform_fmt
         files: '\.tf$'
@@ -133,12 +137,12 @@ repos:
   # SECURITY SCANNING
   # ============================================================================
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.5.7
+    rev: v3.5.9
     hooks:
       - id: ash-simple-scan
 
   - repo: https://github.com/awslabs/ferret-scan
-    rev: v2.1.1
+    rev: v2.3.2
     hooks:
       - id: ferret-scan
         name: Ferret Scan Security Check
@@ -162,7 +166,7 @@ repos:
   # INFRASTRUCTURE SECURITY
   # ============================================================================
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.53.1
+    rev: v1.55.1
     hooks:
       - id: cfn-lint
         exclude: ^\.*
@@ -170,6 +174,15 @@ repos:
   # ============================================================================
   # LICENSE COMPLIANCE
   # ============================================================================
+  # DO NOT bump to 2026.x — `pre-commit autoupdate` will try to. Two regressions
+  # break template consumers:
+  #   1. No pyproject.toml -> hard crash "RuntimeError: All resolvers failed".
+  #      The CLI's hardcoded requirements_paths default ("pyproject.toml")
+  #      overrides the value set in licensecheck.toml, so a project using
+  #      requirements.txt still crashes. Passing --requirements-paths works
+  #      around it, but every path listed must exist or it crashes again.
+  #   2. A project with zero dependencies exits 3 instead of 0.
+  # 2025.1.0 prints "No packages" and exits 0 in both cases.
   - repo: https://github.com/FHPythonUtils/LicenseCheck
     rev: "2025.1.0"
     hooks:

--- a/License.txt
+++ b/License.txt
@@ -201,4 +201,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   


### PR DESCRIPTION
## Summary

Follow-up to #22 / #23. Brings the two secondary pre-commit configs in line with `pre-commit autoupdate`, extends the ferret-scan config with the upstream v2.3.2 additions that are appropriate for a public repo, and fixes a codespell argument that never worked.

## Hook version sync

`pre-commit autoupdate` only touches `.pre-commit-config.yaml`, so the security and security-linting configs had drifted. All three now match:

| Hook | Before | After |
|---|---|---|
| ruff-pre-commit | v0.15.22 | v0.16.3 |
| mirrors-eslint | v10.7.0 | v10.8.1 |
| pre-commit-terraform | v1.108.0 | v1.108.1 |
| automated-security-helper | v3.5.7 | v3.5.9 |
| ferret-scan | v2.1.1 | v2.3.2 |
| cfn-lint | v1.53.1 | v1.55.1 |

Verified all 14 hooks report identical revs across the three files.

## licensecheck stays at 2025.1.0

`autoupdate` wants to bump this to 2026.0.8. It has two regressions that break template consumers, so the pin now carries a comment explaining why in all three configs.

| Scenario | 2025.1.0 | 2026.0.8 |
|---|---|---|
| No `pyproject.toml` | exit 0 | 💥 `RuntimeError: All resolvers failed` |
| Zero dependencies | exit 0 | ❌ exit 3 |

`--requirements-paths` works around the crash but isn't usable here: every path listed must exist, so no single value is safe across consumer repos, and it doesn't address the exit-3 case. The CLI's hardcoded `requirements_paths` default also overrides whatever `licensecheck.toml` sets, so pointing the config at `requirements.txt` doesn't help.

## ferret-scan config

Adopted from upstream v2.3.2:
- New social platforms: `threads`, `bluesky`, `mastodon` (patterns + keywords), 17 → 20
- `respect_gitignore` — `quick: true`, `thorough: false`
- `exclude_patterns` on the `quick` profile

**Deliberately not adopted:** upstream's 17 additional `internal_urls` entries. Those are Amazon-internal hostnames, and publishing them in a public repo would itself leak internal infrastructure naming. `internal_urls` stays at its existing 7 generic cloud patterns. The local `ci`/`ci-junit` profile split is also preserved.

## codespell fix

```yaml
args: [--ignore-words-list=ehr, ser]   # YAML flow sequence -> TWO args
```

This parses to `['--ignore-words-list=ehr', 'ser']`, so `ser` never reached the ignore list and was passed as a stray positional filename instead. `ser` occurs inside the reddit regex `u(?:ser)?` in `.devsecops/ferret-scan.yaml`, so codespell failed with `ser ==> set` on any commit touching that file. Now quoted as one argument, and added to the linting config which had no `args` at all.

Confirmed directly: `--ignore-words-list=ehr` → exit 65; `--ignore-words-list=ehr,ser` → exit 0.

## Testing

- 6/6 new regexes compile under Go RE2 (the engine ferret-scan uses; upstream's earlier twitter pattern used lookbehind, which RE2 rejects)
- Built ferret-scan v2.3.2 from source and scanned a probe file with this config: BLUESKY detected at 100%, MASTODON + THREADS via `SOCIAL_MEDIA_CLUSTER` at 95%, config accepted, exit 0
- `pre-commit run` passes on every changed file
- licensecheck behavior above verified in a clean venv against both versions